### PR TITLE
Workaround for Chrome Painting Bug with Background-Attachment:Fixed

### DIFF
--- a/2014/scripts/main.js
+++ b/2014/scripts/main.js
@@ -151,13 +151,3 @@ window.mapsAsyncInit = function () {
   loadScripts('maps.google.com/maps/api/js?sensor=false&callback=mapsAsyncInit')
   loadScripts('www.google-analytics.com/ga.js')
 }()
-
-// Hotfix for Chrome Paint Bug
-// if (navigator && navigator.userAgent.match(/Chrome\/\d*/)) {
-//   var headerEl = document.querySelector('.header');
-//   document.addEventListener('scroll', function () {
-//     headerEl.style.display = "none";
-//     headerEl.offsetHeight;
-//     headerEl.style.display = "";
-//   });
-// }

--- a/2014/scripts/main.js
+++ b/2014/scripts/main.js
@@ -151,3 +151,13 @@ window.mapsAsyncInit = function () {
   loadScripts('maps.google.com/maps/api/js?sensor=false&callback=mapsAsyncInit')
   loadScripts('www.google-analytics.com/ga.js')
 }()
+
+// Hotfix for Chrome Paint Bug
+// if (navigator && navigator.userAgent.match(/Chrome\/\d*/)) {
+//   var headerEl = document.querySelector('.header');
+//   document.addEventListener('scroll', function () {
+//     headerEl.style.display = "none";
+//     headerEl.offsetHeight;
+//     headerEl.style.display = "";
+//   });
+// }

--- a/2014/styles/main.css
+++ b/2014/styles/main.css
@@ -473,6 +473,7 @@ a {
   background: url(../images/header.jpg) bottom left;
   background-size: cover;
   overflow: hidden;
+  -webkit-transform: translateY(0);
   position: relative; }
   .header:before {
     content: '';


### PR DESCRIPTION
Hey! Should I write in Portuguese or English ? haha.

Well, firstly, congratulations for the website and the event.

Secondly. I saw a little bug with the building in the homepage. Apparently, it's only occurring in Google Chrome.

![image](https://cloud.githubusercontent.com/assets/5850824/4587331/f914ee62-5029-11e4-9495-860c092ce630.png)

So, here is the solution, just a `-webkit-transform: translateY(0);`. At the first moment I tried to force a repaint via javascript as you can see in the main.js file, but it's an ugly solution.
